### PR TITLE
chore: support direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 result
+.direnv


### PR DESCRIPTION
Hi @mkg20001 and thanks for the useful tool!

These days I use [direnv](https://direnv.net/) quite a lot, and I've come to depend on the following NixOS-specific gimmick:

When direnv is used via  `programs.direnv.enabled = true`, the automatically spawned dev shells don't nest, and the environment updates cleanly when editing the `flake.nix` or `shell.nix`. 

That's why, when I see a repo that's already has `flake.nix` or `shell.nix`, my first instinct is to contribute the following 2 lines of configuration.

Otherwise I've seen things get a little messy rather fast; especially when iterating on the devshell manifest, it's easy to end up in a shell within a shell within a slightly different shell...

Is it cool to add this here?